### PR TITLE
Feature/fire change on bad json

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -92,6 +92,13 @@
           "description": "Enables history, adds a button Undo and Redo to the menu of the JSONEditor.\nOnly applicable when mode is 'tree', 'form', or 'preview'",
           "type": "boolean",
           "default": "false"
+        },
+        {
+          "name": "fireChangeOnBadJson",
+          "attribute": "fireChangeOnBadJson",
+          "description": "When set to true, allows change event to still fire, and adds an error property to its evt.detail payload.",
+          "type": "boolean",
+          "default": "false"
         }
       ],
       "events": [

--- a/src/FleshyJsoneditor.js
+++ b/src/FleshyJsoneditor.js
@@ -153,6 +153,10 @@ export class FleshyJsoneditor extends LitElement {
   }
 
   updated(changedProps) {
+    console.log(
+      'TCL ~ file: FleshyJsoneditor.js ~ line 156 ~ FleshyJsoneditor ~ updated ~ changedProps',
+      changedProps
+    );
     super.updated(changedProps);
     if (changedProps.has('mode')) {
       this.editor.setMode(this.mode);
@@ -217,6 +221,10 @@ export class FleshyJsoneditor extends LitElement {
       indentation: this.indentation,
 
       onChange: () => {
+        console.log(
+          'TCL ~ file: FleshyJsoneditor.js ~ line 224 ~ FleshyJsoneditor ~ _initializeEditor _ onChange, this: ',
+          this
+        );
         /* istanbul ignore if  */
         if (!this.editor) {
           return;
@@ -239,6 +247,19 @@ export class FleshyJsoneditor extends LitElement {
         }
         jsonpatch.applyPatch(this.json, patches);
         this._observer = jsonpatch.observe(this.json, this._refresh);
+      },
+
+      onError: error => {
+        console.log(
+          'TCL ~ file: FleshyJsoneditor.js ~ line 252 ~ FleshyJsoneditor ~ _initializeEditor ~ onError _ error:',
+          error
+        );
+      },
+      onModeChange: (newMode, oldMode) => {
+        console.log(
+          'TCL ~ file: FleshyJsoneditor.js ~ line 259 ~ FleshyJsoneditor ~ _initializeEditor ~ newMode:oldmode',
+          { newMode, oldMode }
+        );
       },
     };
 

--- a/src/FleshyJsoneditor.js
+++ b/src/FleshyJsoneditor.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { html, css, LitElement } from 'lit-element';
 import * as jsonpatch from 'fast-json-patch';
 import '../lib/json-editor-import.min.js';

--- a/src/FleshyJsoneditor.js
+++ b/src/FleshyJsoneditor.js
@@ -222,32 +222,43 @@ export class FleshyJsoneditor extends LitElement {
       indentation: this.indentation,
 
       onChange: () => {
-        console.log(
-          'TCL ~ file: FleshyJsoneditor.js ~ line 224 ~ FleshyJsoneditor ~ _initializeEditor _ onChange, this: ',
-          this
-        );
         /* istanbul ignore if  */
-        if (!this.editor) {
-          return;
+        try {
+          if (!this.editor) {
+            return;
+          }
+
+          const patches = jsonpatch.compare(this.json, this.editor.get());
+
+          this.dispatchEvent(
+            new CustomEvent('change', {
+              detail: {
+                json: this.json,
+                patches,
+              },
+            })
+          );
+
+          /* istanbul ignore else  */
+          if (this._observer) {
+            jsonpatch.unobserve(this.json, this._observer);
+          }
+          jsonpatch.applyPatch(this.json, patches);
+          this._observer = jsonpatch.observe(this.json, this._refresh);
+        } catch (e) {
+          console.log(
+            'TCL ~ file: FleshyJsoneditor.js ~ line 249 ~ FleshyJsoneditor ~ _initializeEditor ~ caught error ~ e',
+            e
+          );
+          this.dispatchEvent(
+            new CustomEvent('change', {
+              detail: {
+                json: this.json,
+                error: e,
+              },
+            })
+          );
         }
-
-        const patches = jsonpatch.compare(this.json, this.editor.get());
-
-        this.dispatchEvent(
-          new CustomEvent('change', {
-            detail: {
-              json: this.json,
-              patches,
-            },
-          })
-        );
-
-        /* istanbul ignore else  */
-        if (this._observer) {
-          jsonpatch.unobserve(this.json, this._observer);
-        }
-        jsonpatch.applyPatch(this.json, patches);
-        this._observer = jsonpatch.observe(this.json, this._refresh);
       },
 
       onError: error => {
@@ -260,6 +271,12 @@ export class FleshyJsoneditor extends LitElement {
         console.log(
           'TCL ~ file: FleshyJsoneditor.js ~ line 259 ~ FleshyJsoneditor ~ _initializeEditor ~ newMode:oldmode',
           { newMode, oldMode }
+        );
+      },
+      onValidate: json => {
+        console.log(
+          'TCL ~ file: FleshyJsoneditor.js ~ line 262 ~ FleshyJsoneditor ~ _initializeEditor ~ onValidate ~ json',
+          json
         );
       },
     };

--- a/stories/fleshy-jsoneditor.stories.md
+++ b/stories/fleshy-jsoneditor.stories.md
@@ -125,3 +125,32 @@ export const TreeModeAndNoJSON = () => html`
   <fleshy-jsoneditor mode="tree"></fleshy-jsoneditor>
 `;
 ```
+
+### With `fireChangeOnBadJson` attribute
+
+```js preview-story
+export const fireChangeOnBadJsonAttribute = () => {
+  const handleChange = evt => {
+    const el = document.getElementById('jsonStateSpan');
+    if (evt?.detail.error) {
+      console.log('Bad Json');
+      el.textContent = 'bad';
+    } else {
+      console.log('Good json');
+      el.textContent = 'good';
+    }
+  };
+
+  return html`
+    <fleshy-jsoneditor
+      .json=${json}
+      mode="text"
+      @change=${handleChange}
+      fireChangeOnBadJson
+    ></fleshy-jsoneditor>
+    <div style="margin-top: 20px">
+      JSON state is <span id="jsonStateSpan">unknown (presumed good)</span>
+    </div>
+  `;
+};
+```


### PR DESCRIPTION
Adds new boolean prop `fireChangeOnBadJson`.

The default behaviour (from upstream, I think) when the JSON is in a bad state - e.g. if you delete a JSON key or remove a key's quote marks in text mode - is to throw a JS error (red console) and the change event at the fleshy-jsoneditor level doesn't trigger.  So we can't tell what state the JSON is in.

With the `fireChangeOnBadJson` set to true (default is `false`) , this error is trapped, and the @change event _does_ trigger, and also adds an error property to its evt.detail payload.  The error is still logged in the console as a console.error().

We need this in a downstream project, using this editor, where we have a Save JSON Config button.  We don't want users to be able to click this button when the JSON is in a bad state.
