### PR TITLE
Feature/error event

### DIFF
--- a/src/FleshyJsoneditor.js
+++ b/src/FleshyJsoneditor.js
@@ -153,6 +153,10 @@ export class FleshyJsoneditor extends LitElement {
   }
 
   updated(changedProps) {
+    console.log(
+      'TCL ~ file: FleshyJsoneditor.js ~ line 156 ~ FleshyJsoneditor ~ updated ~ changedProps',
+      changedProps
+    );
     super.updated(changedProps);
     if (changedProps.has('mode')) {
       this.editor.setMode(this.mode);
@@ -217,6 +221,10 @@ export class FleshyJsoneditor extends LitElement {
       indentation: this.indentation,
 
       onChange: () => {
+        console.log(
+          'TCL ~ file: FleshyJsoneditor.js ~ line 224 ~ FleshyJsoneditor ~ _initializeEditor _ onChange, this: ',
+          this
+        );
         /* istanbul ignore if  */
         if (!this.editor) {
           return;
@@ -239,6 +247,19 @@ export class FleshyJsoneditor extends LitElement {
         }
         jsonpatch.applyPatch(this.json, patches);
         this._observer = jsonpatch.observe(this.json, this._refresh);
+      },
+
+      onError: error => {
+        console.log(
+          'TCL ~ file: FleshyJsoneditor.js ~ line 252 ~ FleshyJsoneditor ~ _initializeEditor ~ onError _ error:',
+          error
+        );
+      },
+      onModeChange: (newMode, oldMode) => {
+        console.log(
+          'TCL ~ file: FleshyJsoneditor.js ~ line 259 ~ FleshyJsoneditor ~ _initializeEditor ~ newMode:oldmode',
+          { newMode, oldMode }
+        );
       },
     };
 

--- a/stories/fleshy-jsoneditor.stories.md
+++ b/stories/fleshy-jsoneditor.stories.md
@@ -80,12 +80,10 @@ const modes = ['code', 'form', 'text', 'tree', 'view'];
 export const ModesAttribute = () => {
   const handleError = evt => {
     const el = document.getElementById('jsonStateSpan');
-    console.log('Bad Json');
     el.textContent = 'bad';
   };
   const handleChange = evt => {
     const el = document.getElementById('jsonStateSpan');
-    console.log('Good Json');
     el.textContent = 'good';
   };
   return html`

--- a/stories/fleshy-jsoneditor.stories.md
+++ b/stories/fleshy-jsoneditor.stories.md
@@ -77,9 +77,29 @@ export const NameAttribute = () => html`
 
 ```js preview-story
 const modes = ['code', 'form', 'text', 'tree', 'view'];
-export const ModesAttribute = () => html`
-  <fleshy-jsoneditor .json=${json} .modes="${modes}"></fleshy-jsoneditor>
-`;
+export const ModesAttribute = () => {
+  const handleError = evt => {
+    const el = document.getElementById('jsonStateSpan');
+    console.log('Bad Json');
+    el.textContent = 'bad';
+  };
+  const handleChange = evt => {
+    const el = document.getElementById('jsonStateSpan');
+    console.log('Good Json');
+    el.textContent = 'good';
+  };
+  return html`
+    <fleshy-jsoneditor
+      .json=${json}
+      .modes="${modes}"
+      @change=${handleChange}
+      @error="${handleError}"
+    ></fleshy-jsoneditor>
+    <div style="margin-top: 20px">
+      JSON state is <span id="jsonStateSpan">unknown (presumed good)</span>
+    </div>
+  `;
+};
 ```
 
 ### With `search` attribute set to `true`


### PR DESCRIPTION
Reworked version of PR #18, which I'll close in a moment.

As per @trystan2k 's suggestions, the code now fires an error event of the JSON being in a bad state, which we determine by intercepting the upstream error in a try/catch.

We also pass on any other events from upstream.   I've used a `level` object key in the event detail to distinguish between the two types of error, although I'm not sure if that's really necessary.